### PR TITLE
Fix bundle-audit security flags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source 'https://rubygems.org'
 
 # Serializers
 gem 'builder' # for xml
-gem 'activesupport' # for xml
+gem 'activesupport', '~> 4.0' # for xml
 gem 'multi_json', '~> 1.0'
 gem 'json-schema'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.2)
+    activesupport (4.2.8)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
@@ -36,12 +35,12 @@ GEM
     colorize (0.7.7)
     confstruct (1.0.2)
       hashie (~> 3.3)
-    coveralls (0.7.2)
-      multi_json (~> 1.3)
-      rest-client (= 1.6.7)
-      simplecov (>= 0.7)
-      term-ansicolor (= 1.2.2)
-      thor (= 0.18.1)
+    coveralls (0.8.21)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.14.1)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.4)
+      tins (~> 1.6)
     cucumber (2.0.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.1.3)
@@ -59,6 +58,7 @@ GEM
       capistrano-bundle_audit (>= 0.1.0)
       capistrano-one_time_key
       capistrano-shared_configs
+    docile (1.1.5)
     dotenv (0.7.0)
     druid-tools (0.4.1)
     equivalent-xml (0.6.0)
@@ -73,28 +73,27 @@ GEM
     haml (4.0.6)
       tilt
     hashie (3.5.5)
-    i18n (0.7.0)
-    json (1.8.6)
+    i18n (0.8.4)
+    json (2.1.0)
     json-schema (2.5.1)
       addressable (~> 2.3.7)
     method_source (0.8.2)
-    mime-types (2.6.1)
-    mini_portile (0.6.2)
-    minitest (5.7.0)
+    mini_portile2 (2.2.0)
+    minitest (5.10.2)
     moab-versioning (2.0.0)
       confstruct
       json
       nokogiri
       nokogiri-happymapper
       systemu
-    multi_json (1.11.1)
+    multi_json (1.12.1)
     multi_test (0.1.2)
     mysql2 (0.4.6)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
     pry (0.10.1)
@@ -111,9 +110,7 @@ GEM
       rack (>= 1.0)
     rake (10.4.2)
     randexp (0.1.7)
-    redcarpet (3.3.1)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    redcarpet (3.4.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -129,10 +126,11 @@ GEM
     rspec-support (3.6.0)
     ruby-oci8 (2.1.8)
     sequel (4.23.0)
-    simplecov (0.7.1)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.7.1)
-    simplecov-html (0.7.1)
+    simplecov (0.14.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.1)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -154,17 +152,17 @@ GEM
     sys-filesystem (1.1.4)
       ffi
     systemu (2.6.5)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    term-ansicolor (1.6.0)
+      tins (~> 1.0)
     thin (1.6.3)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0)
       rack (~> 1.0)
-    thor (0.18.1)
-    thread_safe (0.3.5)
+    thor (0.19.4)
+    thread_safe (0.3.6)
     tilt (2.0.1)
-    tins (0.13.2)
-    tzinfo (1.2.2)
+    tins (1.14.0)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     yard (0.8.7.6)
 
@@ -172,7 +170,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
+  activesupport (~> 4.0)
   awesome_print
   builder
   capistrano (> 3.1)


### PR DESCRIPTION
Fix #26 - bundle audit security warnings

This PR runs:
```sh
$ bundle update activesupport coveralls nokogiri redcarpet
```

The `activesupport` is limited to any `4.x` version.

When on the branch for this PR, we get:
```
$  bundle-audit check --update --ignore ''
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up-to-date.
Updated ruby-advisory-db
ruby-advisory-db: 287 advisories
No vulnerabilities found
```
