### PR TITLE
Add management utility scripts

### DIFF
--- a/bin/createBag.rb
+++ b/bin/createBag.rb
@@ -1,0 +1,63 @@
+#!/usr/bin/env ruby
+# must run this from ~/sdr-services-app/current/
+# usage is ruby /directory/of/script/createBag.rb /directory/with/druids/druid-list.txt /some/directory
+# where /directory/of/script/createBag.rb is whereever you place this particular script
+# and where /directory/with/druids/druid-list.txt is whereever your druid file list is
+# NOTE: druids should be each on their own line in the list. Provide either the fully qualified druid (druid:pv564yb1711) or not (pv564yb1711)
+# and where /some/directory is wherever you want the bags to land.  i usually place them in the tmp directory.
+
+# first require some gems
+require 'rubygems'
+require 'bundler/setup'
+require 'moab/stanford'
+include Stanford
+
+module SdrServices
+  Config = Confstruct::Configuration.new do
+      username  nil
+      password nil
+      storage_filesystems nil
+      rsync_destination_host nil
+      rsync_destination_home nil
+  end
+end
+
+# determine environment variables based on the host name
+environment = (
+  case `hostname -s`.chomp
+    when "sul-sdr-services"
+      "production.rb"
+    when "sdr-services-test"
+      "sdr-services-test.rb"
+    else
+      'development'
+  end
+)
+require File.join(ENV['HOME'],"sdr-services-app/current/config/environments/#{environment}")
+
+
+#pull the file from the commandline argument and read each line into the druids array
+druids = []
+druidlist = File.open(ARGV[0])
+druidlist.each_line {|line|
+  druids.push line.chomp
+}
+
+#for each druid in the array
+druids.each do |druid|
+  begin
+  # format the druid into the fully qualified druid if necessary
+    druid = "druid:#{druid}" unless druid.start_with?('druid')
+    # now find the storage object for each one of the objects using the druid
+    storage_object = StorageServices.find_storage_object(druid)
+    # get the current version of the object
+    version_id = storage_object.current_version_id
+    # specify where you want the bags place by pulling from the second argument on the commandline
+    bag_dir = "#{ARGV[1]}/bags/#{druid}"
+    # now using the version_id and the bag_dir, reconstruct the object
+    storage_object.reconstruct_version(version_id, bag_dir)
+  # rescue any errors you might get
+  rescue ObjectNotFoundException => msg
+    puts "#{druid}, #{msg}"
+  end
+end

--- a/bin/objectFileInfor.rb
+++ b/bin/objectFileInfor.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+# must run this from ~/sdr-services-app/current/
+# usage is ruby /directory/of/script/objectFileInfo.rb /directory/with/druids/druid-list.txt
+# where /directory/of/script/objectFileInfo.rb is whereever you place this particular script
+# and where /directory/with/druids/druid-list.txt is whereever your druid file list is
+# NOTE: druids should be each on their own line in the list. Provide either the fully qualified druid (druid:pv564yb1711) or not (pv564yb1711)
+# NOTE: I ususally output this script like so: ruby /tmp/rmetz/objectFileInfo.rb /tmp/rmetz/sdrget-2078.txt > /tmp/rmetz/sdrget-2078.csv
+#and then download it for use in excel
+
+require 'rubygems'
+require 'bundler/setup'
+require 'moab/stanford'
+include Stanford
+
+module SdrServices
+  Config = Confstruct::Configuration.new do
+      username  nil
+      password nil
+      storage_filesystems nil
+      rsync_destination_host nil
+      rsync_destination_home nil
+  end
+end
+
+environment = (
+  case `hostname -s`.chomp
+    when "sul-sdr-services"
+      "production.rb"
+    when "sdr-services-test"
+      "sdr-services-test.rb"
+    else
+      'development'
+  end
+)
+require File.join(ENV['HOME'],"sdr-services-app/current/config/environments/#{environment}")
+
+
+#pull the file from the commandline argument and read each line into the druids array
+druids = []
+druidlist = File.open(ARGV[0])
+druidlist.each_line {|line|
+  druids.push line.chomp
+}
+
+#for each druid in the array
+druids.each do |druid|
+  begin
+    #format the druid so that its fully qualified (unless it already is)
+    druid = "druid:#{druid}" unless druid.start_with?('druid')
+    #pull information about the storage object
+    content_group = StorageServices.retrieve_file_group('content',druid)
+    #then parse that information that you just retrieved
+    content_group.path_hash.each do |file,signature|
+      #into a .csv file that contains the druid, file, md5 checksum, sha1 checksum, sha256 checksum, and the size of the object
+      puts "#{druid}, #{file.to_s}, #{signature.md5}, #{signature.sha1}, #{signature.sha256}, #{signature.size}"
+    end
+  #if the object doesn't exist for some reason, rescue the error message
+  rescue ObjectNotFoundException => msg
+    puts "#{druid}, #{msg}"
+  end
+end


### PR DESCRIPTION
Fix #29 

Two legacy scripts for managing SDR data, to be included in the core app.

- createBag.rb supports SDRGET tasks of retrieving bags for a discrete list of druids
- objectFileInfor.rb supports retrieving a list of checksums from an arbitrary list of druids to provide to stakeholders after ingest is complete so that they can verify content and remove from storage servers (ideally, this would be a self-serve report driven from Argo)

TODO:
- [ ] create specs to excercise functionality in these scripts (or create a new issue for this to be done).