### PR TITLE
deprecate current_version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'moab-versioning', '~> 2.0'
 gem 'haml'
 gem 'redcarpet'
 
+gem 'deprecation'
+
 group :test, :development do
   gem 'awesome_print'
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rvm (> 0.1)
   coveralls
+  deprecation
   dlss-capistrano (> 3.0)
   dotenv
   druid-tools
@@ -200,4 +201,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-[![Build Status](https://travis-ci.org/sul-dlss/sdr-services-app.svg)](https://travis-ci.org/sul-dlss/sdr-services-app) [![Coverage Status](https://coveralls.io/repos/sul-dlss/sdr-services-app/badge.png)](https://coveralls.io/r/sul-dlss/sdr-services-app) 
+[![Build Status](https://travis-ci.org/sul-dlss/sdr-services-app.svg)](https://travis-ci.org/sul-dlss/sdr-services-app) [![Coverage Status](https://coveralls.io/repos/sul-dlss/sdr-services-app/badge.png)](https://coveralls.io/r/sul-dlss/sdr-services-app)
 
 
 # SDR Services Application
 
-A web application for providing access to Digital Objects in SDR Storage.
+A Sinatra web application for providing access to Digital Objects in SDR Storage.
+
+This will be replaced by preservation-catalog as a more robust, easier to maintain approach that won't have to go to the preservation storage roots for absolutely everything.
 
 ## Getting Started
 

--- a/lib/sdr/services_api.rb
+++ b/lib/sdr/services_api.rb
@@ -27,6 +27,7 @@ module Sdr
     helpers do
 
       def latest_version
+        Honeybadger.notify("ServicesAPI deprecated method `latest_version` called - use preservation-client current_version instead")
         @latest_version ||= Stanford::StorageServices.current_version(params[:druid])
       end
       deprecation_deprecate latest_version: 'use preservation-client current_version instead'
@@ -216,7 +217,9 @@ module Sdr
     #     status 200: <currentVersion>1</currentVersion>
     #     status 404: cannot find DRUID-ID
     get '/objects/:druid/current_version' do
-      Deprecation.warn(nil, 'HTTP GET /objects/:druid/current_version is deprecated; use preservation-client current_version instead')
+      depr_msg = 'HTTP GET /objects/:druid/current_version is deprecated; use preservation-client current_version instead'
+      Deprecation.warn(nil, depr_msg)
+      Honeybadger.notify(depr_msg)
       current_version = Stanford::StorageServices.current_version(params[:druid])
       [200, {'content-type' => 'application/xml'}, "<currentVersion>#{current_version.to_s}</currentVersion>"]
     end

--- a/lib/sdr/services_api.rb
+++ b/lib/sdr/services_api.rb
@@ -1,6 +1,7 @@
 require 'moab/stanford'
 require 'druid-tools'
 require 'sys/filesystem'
+require 'deprecation'
 # require "sinatra/base"
 require_relative 'sdr_base'
 
@@ -20,15 +21,15 @@ module Sdr
   # @see https://github.com/sul-dlss/druid-tools
   #
   class ServicesAPI < Sdr::Base
+    extend Deprecation
+    self.deprecation_horizon = 'sdr-services-app is being replaced by preservation-catalog'
 
     helpers do
 
       def latest_version
-        unless @latest_version
-          @latest_version = Stanford::StorageServices.current_version(params[:druid])
-        end
-        @latest_version
+        @latest_version ||= Stanford::StorageServices.current_version(params[:druid])
       end
+      deprecation_deprecate latest_version: 'use preservation-client current_version instead'
 
       def caption(version)
         "Object = #{params[:druid]} - Version = #{version ? version.to_s : latest_version} of #{latest_version}"
@@ -215,6 +216,7 @@ module Sdr
     #     status 200: <currentVersion>1</currentVersion>
     #     status 404: cannot find DRUID-ID
     get '/objects/:druid/current_version' do
+      Deprecation.warn(nil, 'HTTP GET /objects/:druid/current_version is deprecated; use preservation-client current_version instead')
       current_version = Stanford::StorageServices.current_version(params[:druid])
       [200, {'content-type' => 'application/xml'}, "<currentVersion>#{current_version.to_s}</currentVersion>"]
     end


### PR DESCRIPTION
## Why was this change made?

In order to get rid of this Sinatra app, which goes directly to the preservation storage-roots for all its info, we want to migrate that functionality to preservation_catalog.   

The `current_version` functionality is already available;  there is already a preservation-client gem that should be used to get this info, instead of querying this app.

## Was the documentation updated?

via deprecation warnings;  not sure this app is well documented, PLUS, we want to get rid of it.

## Note:

I'm only 90% certain I am doing the deprecation correctly;  the tests gave the warning (to stdout or stderr), so I *think* it's good to go ...