### PR TITLE
deprecate cm-inv-diff; use preservation-client content_inventory_diff instead

### DIFF
--- a/lib/sdr/services_api.rb
+++ b/lib/sdr/services_api.rb
@@ -449,6 +449,9 @@ module Sdr
       # 1. pulls new contentMetadata from Fedora
       # 2. posts that contentMetadata to sdr-service's  cm-inv-diff
       # 3. receives a fileInventoryDifferences report in response
+      depr_msg = 'HTTP POST /objects/:druid/cm-inv-diff is deprecated; use preservation-client content_inventory_diff instead'
+      Deprecation.warn(nil, depr_msg)
+      Honeybadger.notify(depr_msg)
       request.body.rewind
       cmd_xml = request.body.read
       diff = Stanford::StorageServices.compare_cm_to_version(cmd_xml, params[:druid], subset_param(), version_param())


### PR DESCRIPTION
DRAFT:

- ~~should not be deployed until sul-dlss/preservation_catalog/pull/1250 is deployed~~
- ~~should not be deployed until sul-dlss/common-accessioning/pull/465 is deployed~~
- ~~should not be deployed until sul-dlss/dor-services-app/pull/514 is deployed~~

## Why was this change made?

To be certain we didn't miss any spots as we move the `cm-inv-diff` API endpoint here to preservation catalog.  

## Was the documentation (README, API, wiki, consul, etc.) updated?

nah - we're close to being able to kill this app.