### PR TITLE
deprecate manifest; use preservation-client manifest or signature_catalog

### DIFF
--- a/lib/sdr/services_api.rb
+++ b/lib/sdr/services_api.rb
@@ -392,6 +392,9 @@ module Sdr
     #   the remainder are one or more of md5, sha1, or sha256 checksums
     # @return DRUID manifest file
     get '/objects/:druid/manifest/*' do
+      depr_msg = 'HTTP GET /objects/:druid/manifest is deprecated; use preservation-client .manifest or .signature_catalog instead'
+      Deprecation.warn(nil, depr_msg)
+      Honeybadger.notify(depr_msg)
       retrieve_file(params[:druid],'manifest',file_id_param, version_param, signature_param)
     end
 


### PR DESCRIPTION
## Why was this change made?

In order to get rid of this Sinatra app!  This is the very last API call that wasn't yet deprecated. 

To be certain we didn't miss any spots as we move the `manifest` API endpoint from here to preservation catalog.  

## Was the documentation (README, API, wiki, consul, etc.) updated?

yes, in the form of deprecation messages and Honeybadger notifications.

## When can we decommission this app?

After this is deployed (Monday deploy is soon enough), we watch for any Honeybadger alerts;  if none, we can decommission sdr-services-app!